### PR TITLE
feat(dashboard): Melhora a UX do histórico, métricas e gráfico de posições

### DIFF
--- a/src/app/api/trades/route.ts
+++ b/src/app/api/trades/route.ts
@@ -19,9 +19,11 @@ export async function GET(request: NextRequest) {
           },
         },
       },
-      orderBy: {
-        initial_entry_date: 'desc',
-      }
+      orderBy: [
+        { status: 'asc' },
+        { last_exit_date: 'desc' },
+        { initial_entry_date: 'desc' },
+      ]
     });
 
     return NextResponse.json(positions);

--- a/src/app/dashboard/components/DashboardMetrics.tsx
+++ b/src/app/dashboard/components/DashboardMetrics.tsx
@@ -39,6 +39,8 @@ const DashboardMetrics: React.FC<DashboardMetricsProps> = ({
     const averageProfit = winningTrades > 0 ? closedPositions.filter(p => p.total_realized_pnl > 0).reduce((acc, p) => acc + p.total_realized_pnl, 0) / winningTrades : 0;
     const averageLoss = losingTrades > 0 ? closedPositions.filter(p => p.total_realized_pnl < 0).reduce((acc, p) => acc + p.total_realized_pnl, 0) / losingTrades : 0;
 
+    const payoffRatio = averageLoss !== 0 ? Math.abs(averageProfit / averageLoss) : 0;
+
     const handleCapitalEdit = () => {
         if (isEditingCapital) {
             const newCapital = tempCapital;
@@ -54,7 +56,7 @@ const DashboardMetrics: React.FC<DashboardMetricsProps> = ({
         { title: 'Posições Encerradas', value: totalTrades },
         { title: 'Taxa de Acerto', value: formatPercentage(winRate) },
         { title: 'Lucro Médio', value: formatCurrency(averageProfit) },
-        { title: 'Prejuízo Médio', value: formatCurrency(averageLoss) },
+        { title: 'Payoff Ratio', value: payoffRatio.toFixed(2) },
     ];
     
     const currentCapital = initialCapital + totalProfit;

--- a/src/app/dashboard/components/PositionsHistory.tsx
+++ b/src/app/dashboard/components/PositionsHistory.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { Position } from "@/types/trade";
 import PositionCard from "@/components/PositionCard";
 
-interface TradesHistoryProps {
+interface PositionsHistoryProps {
   positions: Position[];
   onOpenDetails: (position: Position) => void;
   onOpenNewTradeModal: () => void;
@@ -22,7 +22,7 @@ interface TradesHistoryProps {
   setResultFilter: (result: "all" | "profit" | "loss") => void;
 }
 
-const TradesHistory: React.FC<TradesHistoryProps> = ({
+const PositionsHistory: React.FC<PositionsHistoryProps> = ({
   positions,
   onOpenDetails,
   onOpenNewTradeModal,
@@ -39,10 +39,10 @@ const TradesHistory: React.FC<TradesHistoryProps> = ({
     <div className="mt-6 mb-6">
       <div className="flex flex-wrap items-center justify-between gap-y-3 gap-x-4 mb-3 sm:mb-4">
         <div className="flex items-center gap-3">
-          <h2 className="text-xl sm:text-2xl font-bold">Histórico de Trades</h2>
+          <h2 className="text-xl sm:text-2xl font-bold">Histórico de Posições</h2>
           <div
             className="flex items-center gap-2"
-            title="Adicionar Trade"
+            title="Adicionar Posição"
           >
             <Button
               variant="outline"
@@ -109,18 +109,26 @@ const TradesHistory: React.FC<TradesHistoryProps> = ({
               Resultado
             </Button>
             <Button
-              variant={resultFilter === "profit" ? "default" : "ghost"}
+              variant={"ghost"}
               size="sm"
               onClick={() => setResultFilter("profit")}
-              className="h-7 text-green-600"
+              className={cn("h-7", {
+                "text-green-600 hover:text-green-700": resultFilter !== "profit",
+                "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400":
+                  resultFilter === "profit",
+              })}
             >
               Lucro
             </Button>
             <Button
-              variant={resultFilter === "loss" ? "default" : "ghost"}
+              variant={"ghost"}
               size="sm"
               onClick={() => setResultFilter("loss")}
-              className="h-7 text-red-600"
+              className={cn("h-7", {
+                "text-red-600 hover:text-red-700": resultFilter !== "loss",
+                "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400":
+                  resultFilter === "loss",
+              })}
             >
               Prejuízo
             </Button>
@@ -140,7 +148,7 @@ const TradesHistory: React.FC<TradesHistoryProps> = ({
             ))
           ) : (
             <div className="col-span-full text-center py-8 text-gray-500 dark:text-gray-400">
-              <p>Nenhum trade encontrado para os filtros selecionados.</p>
+              <p>Nenhuma posição encontrada para os filtros selecionados.</p>
             </div>
           )}
         </div>
@@ -149,4 +157,4 @@ const TradesHistory: React.FC<TradesHistoryProps> = ({
   );
 };
 
-export default TradesHistory;
+export default PositionsHistory; 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -15,7 +15,7 @@ import { Position } from "@/types/trade";
 import { useAuth } from "@/contexts/AuthContext";
 import DashboardHeader from "./components/DashboardHeader";
 import DashboardMetrics from "./components/DashboardMetrics";
-import TradesHistory from "./components/TradesHistory";
+import PositionsHistory from "./components/PositionsHistory";
 import ConfirmationModal from "@/components/ui/ConfirmationModal";
 import Loader from "@/components/ui/Loader";
 import PositionForm, { PositionFormData } from "@/components/PositionForm";
@@ -65,6 +65,14 @@ const DashboardPage: React.FC = () => {
     try {
       const response = await getPositions();
       setPositions(response);
+
+      setSelectedPosition((currentSelected) => {
+        if (!currentSelected) return null;
+        const updatedPosition = response.find(
+          (p) => p.id === currentSelected.id
+        );
+        return updatedPosition || null;
+      });
     } catch (error) {
       console.error("Erro ao carregar posições:", error);
     }
@@ -113,11 +121,8 @@ const DashboardPage: React.FC = () => {
 
   const totalProfit = useMemo(() => {
     return positions
-      .filter(pos => pos.status === 'Closed')
-      .reduce(
-        (acc, pos) => acc + (pos.total_realized_pnl ?? 0),
-        0
-      );
+      .filter((pos) => pos.status === "Closed")
+      .reduce((acc, pos) => acc + (pos.total_realized_pnl ?? 0), 0);
   }, [positions]);
 
   const isFilterActive =
@@ -180,11 +185,6 @@ const DashboardPage: React.FC = () => {
     setSelectedPosition(null);
   };
 
-  const handleUpdateAndClose = () => {
-    loadPositions();
-    handleCloseDetailsModal();
-  };
-
   return (
     <>
       <DashboardHeader logout={logout} />
@@ -194,7 +194,7 @@ const DashboardPage: React.FC = () => {
           <h2 className="text-xl sm:text-2xl font-bold">Visão Geral</h2>
           <Button onClick={handleOpenNewTradeModal}>
             <PlusCircle className="mr-2 h-4 w-4" />
-            Adicionar Trade
+            Adicionar Posição
           </Button>
         </div>
 
@@ -209,7 +209,7 @@ const DashboardPage: React.FC = () => {
           setTempCapital={setTempCapital}
         />
 
-        <TradesHistory
+        <PositionsHistory
           positions={filteredPositions}
           onOpenDetails={handleOpenDetailsModal}
           onOpenNewTradeModal={handleOpenNewTradeModal}
@@ -241,7 +241,7 @@ const DashboardPage: React.FC = () => {
         <PositionDetailsModal
           position={selectedPosition}
           onClose={handleCloseDetailsModal}
-          onUpdate={handleUpdateAndClose}
+          onUpdate={loadPositions}
         />
       )}
 

--- a/src/components/CumulativeProfitChart.tsx
+++ b/src/components/CumulativeProfitChart.tsx
@@ -16,6 +16,7 @@ import {
   ChartOptions,
 } from "chart.js";
 import { Position } from "@/types/trade";
+import { formatCurrency } from "@/lib/utils";
 
 ChartJS.register(
   CategoryScale,
@@ -72,7 +73,7 @@ const CumulativeProfitChart: React.FC<CumulativeProfitChartProps> = ({
 
   sortedPositions.forEach((position, index) => {
     cumulativeProfit += Number(position.total_realized_pnl);
-    chartData.labels!.push(`Trade ${index + 1}`);
+    chartData.labels!.push(position.ticker);
     (chartData.datasets[0].data as number[]).push(cumulativeProfit);
   });
 
@@ -94,7 +95,19 @@ const CumulativeProfitChart: React.FC<CumulativeProfitChartProps> = ({
       tooltip: {
         callbacks: {
           label: function (context) {
-            return `Lucro Acumulado: R$ ${context.parsed.y.toFixed(2)}`;
+            if (context.dataIndex === 0) {
+              return "Capital Inicial";
+            }
+            return `Lucro Acumulado: ${formatCurrency(context.parsed.y)}`;
+          },
+          afterLabel: function (context) {
+            const positionIndex = context.dataIndex - 1;
+            if (positionIndex >= 0 && sortedPositions[positionIndex]) {
+              const position = sortedPositions[positionIndex];
+              const result = position.total_realized_pnl;
+              return `Resultado da Posição: ${formatCurrency(result)}`;
+            }
+            return "";
           },
         },
       },


### PR DESCRIPTION
## Descrição

Este PR introduz uma série de melhorias e correções de usabilidade no dashboard e na visualização de detalhes das posições. As alterações visam fornecer dados mais ricos, melhorar o fluxo de interação do usuário e corrigir a ordenação dos dados.

## Alterações Realizadas

### 📈 Dashboard e Gráfico
- **Métricas:** A métrica "Prejuízo Médio" foi substituída pelo **Payoff Ratio** para uma análise de performance mais eficaz.
- **Gráfico de Lucro Acumulado:**
    - O eixo X agora exibe o **ticker** de cada posição em vez de um número genérico ("Trade 1", "Trade 2"), facilitando a identificação.
    - O *tooltip* (dica de contexto ao passar o mouse) foi aprimorado para mostrar não apenas o lucro acumulado, mas também o **resultado individual** daquela posição específica.

### 📋 Histórico de Posições
- **Renomeação:** O componente `TradesHistory` foi renomeado para `PositionsHistory` para melhor clareza semântica.
- **Ordenação:** A ordenação no backend foi corrigida para que as posições **abertas** apareçam sempre primeiro, seguidas pelas fechadas, que são ordenadas pela data de saída mais recente.
- **Filtros:** Os botões de filtro "Lucro" e "Prejuízo" receberam novos estilos para os estados `hover` e `active`, melhorando o feedback visual.

###  modal de Detalhes da Posição
- **Histórico de Operações:** Saídas parciais agora exibem o **resultado percentual (P/L %)** em relação ao preço médio de entrada.
- **Exclusão:** Foi adicionado um **estado de loading** ao botão de confirmação de exclusão para dar um feedback claro ao usuário.
- **Fluxo de UX:** Ao registrar um incremento ou uma saída parcial, o modal de detalhes agora permanece aberto e **atualiza seus próprios dados**, evitando que o usuário seja redirecionado para o dashboard a cada pequena alteração.