### PR TITLE
feat: Adiciona exibição de capital alocado no dashboard e posições

### DIFF
--- a/src/app/dashboard/components/DashboardMetrics.tsx
+++ b/src/app/dashboard/components/DashboardMetrics.tsx
@@ -41,6 +41,10 @@ const DashboardMetrics: React.FC<DashboardMetricsProps> = ({
 
     const payoffRatio = averageLoss !== 0 ? Math.abs(averageProfit / averageLoss) : 0;
 
+    const allocatedCapital = positions
+        .filter((p) => p.status === 'Open')
+        .reduce((acc, p) => acc + p.current_quantity * p.average_entry_price, 0);
+
     const handleCapitalEdit = () => {
         if (isEditingCapital) {
             const newCapital = tempCapital;
@@ -54,6 +58,7 @@ const DashboardMetrics: React.FC<DashboardMetricsProps> = ({
 
     const metricCards = [
         { title: 'Posições Encerradas', value: totalTrades },
+        { title: 'Capital Alocado', value: formatCurrency(allocatedCapital) },
         { title: 'Taxa de Acerto', value: formatPercentage(winRate) },
         { title: 'Lucro Médio', value: formatCurrency(averageProfit) },
         { title: 'Payoff Ratio', value: payoffRatio.toFixed(2) },

--- a/src/components/PositionCard.tsx
+++ b/src/components/PositionCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
-import { cn, formatDate } from "@/lib/utils";
+import { cn, formatCurrency, formatDate } from "@/lib/utils";
 import { TrendingDown, TrendingUp, Clock, CheckCircle } from "lucide-react";
 import { Position } from "../types/trade";
 
@@ -13,29 +13,42 @@ const PositionCard: React.FC<PositionCardProps> = ({ position, onClick }) => {
   const isProfit = position.total_realized_pnl >= 0;
 
   const closedPositionMetrics = React.useMemo(() => {
-    if (position.status !== 'Closed' || !position.operations || position.operations.length === 0) {
+    if (
+      position.status !== "Closed" ||
+      !position.operations ||
+      position.operations.length === 0
+    ) {
       return { total_quantity: 0, average_exit_price: 0 };
     }
 
-    const entryOperations = position.operations.filter(op => op.operation_type === 'Entry' || op.operation_type === 'Increment');
-    const exitOperations = position.operations.filter(op => op.operation_type === 'PartialExit');
+    const entryOperations = position.operations.filter(
+      (op) => op.operation_type === "Entry" || op.operation_type === "Increment"
+    );
+    const exitOperations = position.operations.filter(
+      (op) => op.operation_type === "PartialExit"
+    );
 
-    const total_quantity = entryOperations.reduce((acc, op) => acc + op.quantity, 0);
-    
+    const total_quantity = entryOperations.reduce(
+      (acc, op) => acc + op.quantity,
+      0
+    );
+
     let average_exit_price = 0;
     if (exitOperations.length > 0) {
-      const totalExitValue = exitOperations.reduce((acc, op) => acc + (op.price * op.quantity), 0);
-      const totalExitQuantity = exitOperations.reduce((acc, op) => acc + op.quantity, 0);
-      average_exit_price = totalExitQuantity > 0 ? totalExitValue / totalExitQuantity : 0;
+      const totalExitValue = exitOperations.reduce(
+        (acc, op) => acc + op.price * op.quantity,
+        0
+      );
+      const totalExitQuantity = exitOperations.reduce(
+        (acc, op) => acc + op.quantity,
+        0
+      );
+      average_exit_price =
+        totalExitQuantity > 0 ? totalExitValue / totalExitQuantity : 0;
     }
-    
+
     return { total_quantity, average_exit_price };
   }, [position]);
-
-  const formatCurrency = (value: number | null | undefined): string => {
-    if (value === null || value === undefined) return "N/A";
-    return `R$ ${Number(value).toFixed(2)}`;
-  };
 
   const displayDate = formatDate(
     position.status === "Open"
@@ -91,7 +104,9 @@ const PositionCard: React.FC<PositionCardProps> = ({ position, onClick }) => {
             <>
               <div className="flex justify-between items-center text-xs sm:text-sm">
                 <span className="text-muted-foreground">Qtd. Total:</span>
-                <span className="font-medium">{closedPositionMetrics.total_quantity}</span>
+                <span className="font-medium">
+                  {closedPositionMetrics.total_quantity}
+                </span>
               </div>
               <div className="flex justify-between items-center text-xs sm:text-sm">
                 <span className="text-muted-foreground">
@@ -122,6 +137,14 @@ const PositionCard: React.FC<PositionCardProps> = ({ position, onClick }) => {
                 </span>
                 <span className="font-medium">
                   {formatCurrency(position.average_entry_price)}
+                </span>
+              </div>
+              <div className="flex justify-between items-center text-xs sm:text-sm">
+                <span className="text-muted-foreground">Capital Alocado:</span>
+                <span className="font-medium">
+                  {formatCurrency(
+                    position.current_quantity * position.average_entry_price
+                  )}
                 </span>
               </div>
             </>

--- a/src/components/PositionDetailsModal.tsx
+++ b/src/components/PositionDetailsModal.tsx
@@ -353,6 +353,18 @@ const PositionDetailsModal: React.FC<PositionDetailsModalProps> = ({
                 </p>
               </div>
             )}
+            {position.status === "Open" && (
+              <div>
+                <label className="text-xs sm:text-sm font-medium text-muted-foreground">
+                  Capital Alocado
+                </label>
+                <p className="mt-1 text-sm sm:text-base font-medium">
+                  {formatCurrency(
+                    position.current_quantity * position.average_entry_price
+                  )}
+                </p>
+              </div>
+            )}
             <div>
               <label className="text-xs sm:text-sm font-medium text-muted-foreground">
                 {position.status === "Closed"


### PR DESCRIPTION
### Descrição

Este Pull Request adiciona a métrica de "Capital Alocado" à interface do usuário, fornecendo mais visibilidade sobre o capital que está atualmente em uso nas posições abertas. A informação foi adicionada em três locais principais: no dashboard, nos cards de posição e no modal de detalhes da posição.

### Alterações Implementadas

- **Dashboard (`DashboardMetrics.tsx`):**
  - Adicionado um novo item no card de "Métricas" para exibir o "Capital Alocado" total, que representa a soma do capital de todas as posições em aberto.

- **Card de Posição (`PositionCard.tsx`):**
  - Para posições com status "Aberta", o card agora mostra o "Capital Alocado", calculado como `quantidade atual * preço médio de entrada`.

- **Modal de Detalhes da Posição (`PositionDetailsModal.tsx`):**
  - Incluída a informação de "Capital Alocado" na grade de detalhes da posição, visível apenas para posições que ainda estão abertas.
